### PR TITLE
Mostrar a mensagem na tela de cadastro de clientes

### DIFF
--- a/src/php/cabecalho.php
+++ b/src/php/cabecalho.php
@@ -1,4 +1,5 @@
 <?php 
+session_start();
 require_once("conecta.php"); 
 
 $consulta1 = "select * from dados_cliente"; 

--- a/src/php/formulario-cliente.php
+++ b/src/php/formulario-cliente.php
@@ -41,6 +41,7 @@
 					</button>
 					<button type="submit" class="btn btn-primary btn-lg botao-enviar">Enviar</button>
 					<a href="../php/index.php" class="btn btn-danger btn-lg botao-voltar" role="button">Voltar</a>
+					<div><?=$_SESSION['msg']?></div>
 					<!-- Button trigger modal -->
 
 


### PR DESCRIPTION
Esta alteração permite ver a mensagem da Session e entender se a operação foi concluída com sucesso, pode ser aplicado também ao cadastro de cursos.

![image](https://user-images.githubusercontent.com/13732120/46239064-aca0c580-c369-11e8-9c47-60a867851ec2.png)
